### PR TITLE
fix: use PAT for release-please to enable label creation

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
 
   build-and-release:
     needs: release-please
@@ -69,4 +69,4 @@ jobs:
           files: |
             Phishy-${{ needs.release-please.outputs.tag_name }}-${{ matrix.name }}.zip
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
Fix the release-please workflow to use a Personal Access Token (PAT) instead of the default GITHUB_TOKEN to enable label creation permissions.

## Problem
The release-please workflow was failing with:
```
release-please failed: You do not have permission to create labels on this repository
```

This happened because the default GITHUB_TOKEN has limited permissions and cannot create labels.

## Solution
- Use `RELEASE_PLEASE_TOKEN` secret (containing a PAT with full permissions)
- Fallback to `GITHUB_TOKEN` if the secret is not available
- Apply the same token to artifact uploads for consistency

## Test Plan
- [x] Create repository secret `RELEASE_PLEASE_TOKEN` with PAT
- [x] Update workflow to use the new token
- [ ] Merge this PR
- [ ] Verify next release-please run creates labels successfully
- [ ] Confirm PR #6 (release PR) gets proper labels

This will ensure the release-please workflow has all necessary permissions to:
- Create pull requests ✅
- Create labels ✅
- Update releases ✅
- Upload artifacts ✅