### PR TITLE
fix: correct license inconsistency - README claimed MIT but uses AGPL-3.0

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,11 @@
+Phishy - Out-of-process fishing automation tool for World of Warcraft
+Copyright (C) 2024-2025 stdNullPtr
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published
+by the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
                     GNU AFFERO GENERAL PUBLIC LICENSE
                        Version 3, 19 November 2007
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
       <img alt="Downloads" src="https://img.shields.io/github/downloads/stdNullPtr/Phishy/total?style=for-the-badge&logo=github">
     </a>
     <a href="https://github.com/stdNullPtr/Phishy/blob/master/LICENSE">
-      <img alt="License" src="https://img.shields.io/github/license/stdNullPtr/Phishy?style=for-the-badge">
+      <img alt="License" src="https://img.shields.io/badge/license-AGPL--3.0-blue?style=for-the-badge">
     </a>
   </p>
   
@@ -270,7 +270,16 @@ Please ensure your code follows the existing patterns and includes appropriate e
 
 ## 📜 License
 
-This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
+This project is licensed under the **GNU Affero General Public License v3.0 (AGPL-3.0)** - see the [LICENSE](LICENSE) file for details.
+
+### What this means:
+- ✅ **Free to use, modify, and distribute**
+- ✅ **Commercial use is allowed**
+- ✅ **All derivatives MUST be open source**
+- ✅ **Network use requires source disclosure**
+- ⚠️ **Strong copyleft - changes must use AGPL-3.0**
+
+The AGPL ensures that all modifications and derivatives remain open source, even when used as a network service. If you modify this code and provide it as a service, you must share your source code.
 
 ## 🙏 Acknowledgments
 


### PR DESCRIPTION
## Summary

This PR fixes a critical license inconsistency where the README incorrectly claimed MIT License while the actual LICENSE file contains GNU Affero General Public License v3.0 (AGPL-3.0).

## Problem

- **README.md**: Incorrectly stated "MIT License"
- **LICENSE file**: Actually contains AGPL v3.0
- This mismatch could cause legal confusion

## Solution

- Updated README to correctly state **GNU Affero General Public License v3.0**
- Added proper copyright header to LICENSE file
- Updated license badge to show AGPL-3.0
- Clarified what AGPL means for users

## Why AGPL-3.0?

AGPL-3.0 is perfect for this project because:
- ✅ **Allows commercial use** - Anyone can make money from it
- ✅ **Forces derivatives to be open source** - Prevents proprietary forks
- ✅ **Network copyleft** - Even SaaS must share source code
- ✅ **Community benefits** - All improvements come back to everyone

This ensures the project remains open source forever while allowing commercial use, as long as derivatives share their code.

## Changes

1. **LICENSE file**:
   - Added Phishy copyright header (2024-2025 stdNullPtr)
   - Kept full AGPL-3.0 text

2. **README.md**:
   - Fixed license claim from MIT to AGPL-3.0
   - Updated badge to show AGPL-3.0
   - Added clear explanation of copyleft requirements

## Impact

- No breaking changes for users
- Clarifies actual license terms
- Ensures legal consistency