### PR TITLE
feat: auto-assign all PRs to maintainer

### DIFF
--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -1,0 +1,26 @@
+name: Auto-assign PRs
+
+on:
+  pull_request:
+    types: [opened]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  auto-assign:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Auto-assign PR to maintainer
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            github.rest.issues.addAssignees({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              assignees: ['stdNullPtr']
+            });
+            
+            console.log('Auto-assigned PR #' + context.issue.number + ' to stdNullPtr');


### PR DESCRIPTION
## Summary
Add GitHub Actions workflow to automatically assign all new pull requests to the maintainer.

## Changes
- Added `.github/workflows/auto-assign.yml`
- Triggers on `pull_request: opened` events
- Uses `actions/github-script@v7` to assign PRs to `stdNullPtr`
- Requires only `pull-requests: write` permission

## Implementation Details
```yaml
on:
  pull_request:
    types: [opened]
```

The workflow uses GitHub's REST API to add the maintainer as an assignee:
```javascript
github.rest.issues.addAssignees({
  owner: context.repo.owner,
  repo: context.repo.repo, 
  issue_number: context.issue.number,
  assignees: ['stdNullPtr']
});
```

This ensures consistent assignment of all incoming pull requests for review tracking.