### PR TITLE
feat: add interact key fishing mode support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,6 +69,22 @@ The audio detection system is critical for fish detection:
 - Resource disposal for COM objects
 - Exit key is END (not DEL)
 
+### Interact Key Feature
+
+The bot supports two fishing modes:
+
+1. **Traditional Mode (default)**: Uses cursor detection + mouse clicks
+   - Detects bobber via cursor icon changes (EVENT_OBJECT_NAMECHANGE)
+   - Moves mouse in spiral pattern to find bobber
+   - Right-clicks on bobber to catch fish
+
+2. **Interact Key Mode**: Uses WoW's "Interact with Target" feature
+   - Set `use-interact-key: true` in configuration.yaml
+   - Configure `keyboard-key-interact` (default: f)
+   - Skips bobber detection entirely
+   - Uses keyboard interaction instead of mouse clicks
+   - Requires WoW expansion that supports interact feature (not available in vanilla)
+
 ### Testing Audio Issues
 
 If audio detection isn't working:

--- a/Phishy/Configs/ConfigValidator.cs
+++ b/Phishy/Configs/ConfigValidator.cs
@@ -48,13 +48,6 @@ public class ConfigValidator
             }
         }
 
-        if (properties.UseInteractKey)
-        {
-            if (string.IsNullOrWhiteSpace(properties.KeyboardKeyInteract))
-            {
-                errors.Add("KeyboardKeyInteract is required when UseInteractKey is enabled");
-            }
-        }
 
         return new ValidationResult(errors);
     }

--- a/Phishy/Configs/ConfigValidator.cs
+++ b/Phishy/Configs/ConfigValidator.cs
@@ -48,6 +48,14 @@ public class ConfigValidator
             }
         }
 
+        if (properties.UseInteractKey)
+        {
+            if (string.IsNullOrWhiteSpace(properties.KeyboardKeyInteract))
+            {
+                errors.Add("KeyboardKeyInteract is required when UseInteractKey is enabled");
+            }
+        }
+
         return new ValidationResult(errors);
     }
 }

--- a/Phishy/Configs/Properties.cs
+++ b/Phishy/Configs/Properties.cs
@@ -38,8 +38,8 @@ public sealed class Properties
     [YamlMember(Description = "Use interact key instead of mouse clicking for fishing (requires WoW expansion with interact feature, Default: false)")]
     public bool UseInteractKey { get; set; }
 
-    [YamlMember(Description = "Keyboard key binding for interact with target (required if UseInteractKey is true, Default: f)")]
-    public string? KeyboardKeyInteract { get; set; }
+    [YamlMember(Description = "Keyboard key binding for interact with target (Default: f)")]
+    public string KeyboardKeyInteract { get; set; }
 
     public Properties()
     {

--- a/Phishy/Configs/Properties.cs
+++ b/Phishy/Configs/Properties.cs
@@ -35,6 +35,12 @@ public sealed class Properties
     [YamlMember(Description = "Window name of the game, when you hover over it in the taskbar")]
     public string GameWindowName { get; set; }
 
+    [YamlMember(Description = "Use interact key instead of mouse clicking for fishing (requires WoW expansion with interact feature, Default: false)")]
+    public bool UseInteractKey { get; set; }
+
+    [YamlMember(Description = "Keyboard key binding for interact with target (required if UseInteractKey is true, Default: f)")]
+    public string? KeyboardKeyInteract { get; set; }
+
     public Properties()
     {
         KeyboardPressLogout = KeyboardUtils.ConvertToString(Keys.D3);
@@ -46,5 +52,7 @@ public sealed class Properties
         SecondLureBuffDurationMinutes = null;
         FishingChannelDurationSeconds = TimeSpan.FromSeconds(20).Seconds;
         GameWindowName = "Game Window Name";
+        UseInteractKey = false;
+        KeyboardKeyInteract = KeyboardUtils.ConvertToString(Keys.F);
     }
 }

--- a/Phishy/Configs/Properties.cs
+++ b/Phishy/Configs/Properties.cs
@@ -53,6 +53,6 @@ public sealed class Properties
         FishingChannelDurationSeconds = TimeSpan.FromSeconds(20).Seconds;
         GameWindowName = "Game Window Name";
         UseInteractKey = false;
-        KeyboardKeyInteract = KeyboardUtils.ConvertToString(Keys.F);
+        KeyboardKeyInteract = "f";
     }
 }

--- a/Phishy/FishingStateMachine.cs
+++ b/Phishy/FishingStateMachine.cs
@@ -55,8 +55,15 @@ public class FishingStateMachine : IFishingStateMachine
                     _isBobberFound = false;
                 }
 
-                Console.WriteLine("[FishingStateMachine]: Moving to center of screen...");
-                MouseUtils.MoveToCenterOfWindow(AppConfig.Props.GameWindowName, true, 100);
+                if (!AppConfig.Props.UseInteractKey)
+                {
+                    Console.WriteLine("[FishingStateMachine]: Moving to center of screen...");
+                    MouseUtils.MoveToCenterOfWindow(AppConfig.Props.GameWindowName, true, 100);
+                }
+                else
+                {
+                    Console.WriteLine("[FishingStateMachine]: Interact mode enabled - skipping mouse positioning...");
+                }
 
                 TryTransition();
                 break;
@@ -303,8 +310,8 @@ public class FishingStateMachine : IFishingStateMachine
                 maxSoundLevel = currentSoundLevel;
             }
             
-            // Log every 2 seconds or when significant sound detected
-            if (DateTime.Now - lastLogTime > TimeSpan.FromSeconds(2) || currentSoundLevel > 0.01f)
+            // Log every 5 seconds or when significant sound detected (higher threshold)
+            if (DateTime.Now - lastLogTime > TimeSpan.FromSeconds(5) || currentSoundLevel > 0.05f)
             {
                 string statusMsg = AppConfig.Props.UseInteractKey 
                     ? $"Interact mode: Ready, Current sound: {currentSoundLevel:F4}, Max sound: {maxSoundLevel:F4}, Checks: {checkCount}"

--- a/Phishy/FishingStateMachine.cs
+++ b/Phishy/FishingStateMachine.cs
@@ -126,7 +126,7 @@ public class FishingStateMachine : IFishingStateMachine
                 if (AppConfig.Props.UseInteractKey)
                 {
                     Console.WriteLine($"[FishingStateMachine]: Using interact key: {AppConfig.Props.KeyboardKeyInteract}");
-                    KeyboardUtils.SendKeyInput(AppConfig.Props.KeyboardKeyInteract!);
+                    KeyboardUtils.SendKeyInput(AppConfig.Props.KeyboardKeyInteract);
                 }
                 else
                 {

--- a/Phishy/Utils/KeyboardUtils.cs
+++ b/Phishy/Utils/KeyboardUtils.cs
@@ -10,7 +10,16 @@ internal class KeyboardUtils
 
     public static void SendKeyInput(string key)
     {
-        SendKeys.SendWait("{" + key + "}");
+        // For single letter keys, send without braces to get lowercase
+        // For special keys (like numbers converted from Keys.D1), use braces
+        if (key.Length == 1 && char.IsLetter(key[0]))
+        {
+            SendKeys.SendWait(key.ToLower());
+        }
+        else
+        {
+            SendKeys.SendWait("{" + key + "}");
+        }
     }
 
     public static string ConvertToString(Keys key)


### PR DESCRIPTION
## Summary

- Implements configurable interact key mode as requested in #2
- Provides bot-detection-safer alternative by eliminating mouse movement patterns
- Maintains existing audio-based fish detection system

## Technical Implementation

**Configuration Options:**
```yaml
use-interact-key: false          # Enable interact mode (default: false)  
keyboard-key-interact: f         # Interact key binding (default: f)
```

![image](https://github.com/user-attachments/assets/d173c21c-6a77-4842-b441-a4fdf8709b9d)

**State Machine Changes:**
- `CastLine` → `WaitAndCatch` (skips `FindBobber` when interact mode enabled)
- `CatchFish` uses `KeyboardUtils.SendKeyInput()` instead of `MouseUtils.SendMouseInput()`
- Audio detection works without bobber detection in interact mode

**Validation:**
- `KeyboardKeyInteract` required when `UseInteractKey` is enabled
- Maintains backward compatibility with existing configurations

## Test Plan

- [x] Builds without errors (warning fixed for null reference)
- [x] Config validation works for interact key requirements
- [x] State machine transitions correctly skip FindBobber in interact mode
- [x] Audio detection adapted for interact mode
- [x] Runtime testing with WoW client

Closes #2